### PR TITLE
Fix crash on very early out-of-game click

### DIFF
--- a/src/VirtualKeyMap.cpp
+++ b/src/VirtualKeyMap.cpp
@@ -105,7 +105,14 @@ void VirtualKeyMap::AddVkCombosForCommand(Command command, std::vector<std::stri
 
 std::vector<std::vector<std::uint32_t>> VirtualKeyMap::GetVkCombosOfCommand(Command command)
 {
-    return vkcombos_of_command.at(command);
+    if (vkcombos_of_command.contains(command))
+    {
+        return vkcombos_of_command.at(command);
+    }
+    else
+    {
+        return {};
+    }
 }
 
 void VirtualKeyMap::UpdateVkCombosOfCommandMap()


### PR DESCRIPTION
I've been annoyed by this for a bit so I decided to open the crash dump and it seems to be a simple change. I can't currently test it, unfortunately, as any build I do (even unmodified) crashes, but the dump was of an exception being thrown here.