### PR TITLE
Fix DKUtil submodule version

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Find it on [Nexusmods](https://www.nexusmods.com/baldursgate3/mods/781).
 git clone https://github.com/Ch4nKyy/BG3WASD.git
 cd BG3WASD
 git submodule init
-git submodule update
+git submodule update --remote
 .\build-release.ps1
 ```
 


### PR DESCRIPTION
I've ran `git submodule update --remote` to update [DKUtil](https://github.com/gottyduke/DKUtil/) to the last version, which also fixes [this issue](https://github.com/Ch4nKyy/BG3WASD/issues/39), and altered instructions so that the submodule would be up-to-date at all times.